### PR TITLE
bashrc: redo /etc/profile sourcing removal

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -15,8 +15,6 @@ _is_posix(){ shopt -oq posix; }
 # should go into ~/.bash_profile.  Personal aliases and functions should
 # go into ~/.bashrc
 
-. /etc/profile
-
 # Provides prompt for non-login shells, specifically shells started
 # in the X environment.
 

--- a/bashrc.d/90-bash-completion
+++ b/bashrc.d/90-bash-completion
@@ -1,0 +1,5 @@
+# load bash-completion if installed
+
+if [[ -r /usr/share/bash-completion/bash_completion ]]; then
+  . /usr/share/bash-completion/bash_completion
+fi


### PR DESCRIPTION
Reasons why this should be removed were stated in 3fd6616. Non-login interactive shells just should NOT load /etc/profile.

Loading /etc/profile causes PATH environment variable to be overwritten, causing issues like broken VSCode remote cli support.

The regression on bash-completion was caused by somewhat upstream misleading. The script in profile.d is not widely used actually. There's another one which is usually installed at /usr/share/bash-completion. We can load that one in bashrc.d, just like other distros do.