### PR TITLE
bashrc: only set default HISTFILESIZE when no default has been set

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -157,7 +157,7 @@ IFS="$_IFS"
 export PATH MANPATH
 
 # Setup some environment variables.
-export HISTFILESIZE=4096
+export HISTFILESIZE="${HISTFILESIZE:-4096}"
 
 # Timezone variable $TZ, Wine and stuff alike need it.
 export TZ="$(readlink /etc/localtime | sed -e 's/^\.\.//g' -e 's@/usr/share/zoneinfo/@@')"


### PR DESCRIPTION
The current behavior effectively voids any attempt to set it higher than 4096. The history will be trimmed when /etc/bashrc is sourced, no matter how much higher you set the value before or after sourcing it in your own bashrc.

One can unset the variable, or set a new value and execute bash to see the effect for themselves.