### PR TITLE
fix: set DIR_COLORS for non-login shells

### DIFF
--- a/bashrc.d/25-coreutils.sh
+++ b/bashrc.d/25-coreutils.sh
@@ -1,0 +1,1 @@
+../profile.d/25-coreutils.sh


### PR DESCRIPTION
Without this it's too easy to miss a dangling symlink in a graphical terminal emulator.